### PR TITLE
Add optional first-media liker

### DIFF
--- a/background.js
+++ b/background.js
@@ -161,11 +161,94 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return sendResponse({ ok: !!authorized });
       }
 
-      if (
-        ["START", "FOLLOW_ONE", "STOP", "AF_SET_ALARM", "AF_CLEAR_ALARM"].includes(
-          msg?.type
-        )
-      ) {
+        if (msg?.type === "LIKE_FIRST_MEDIA") {
+          const { auth, auth_lockUntil = 0, af_state = {} } = await chrome.storage.local.get([
+            "auth",
+            "auth_lockUntil",
+            "af_state",
+          ]);
+          const authorized = isAuthorized(auth, auth_lockUntil, now);
+          const paused = af_state.pausedUntil && af_state.pausedUntil > now;
+          const finished = af_state.stage >= 2;
+          if (!authorized || paused || finished) {
+            return sendResponse({ ok: false, error: "UNAUTHORIZED" });
+          }
+
+          const profileUrl = msg.profileUrl;
+          if (!profileUrl) return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
+          console.log("[BG/LIKER] requesting like for", profileUrl);
+
+          let tab;
+          try {
+            tab = await new Promise((resolve) =>
+              chrome.tabs.create({ url: profileUrl, active: true }, resolve)
+            );
+          } catch (e) {
+            console.error("[BG/LIKER] create tab fail", e);
+            return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
+          }
+
+          try {
+            await chrome.windows.update(tab.windowId, { focused: true });
+            await chrome.tabs.update(tab.id, { active: true });
+
+            const completed = new Promise((resolve) => {
+              const listener = (tid, info) => {
+                if (tid === tab.id && info.status === "complete") {
+                  chrome.tabs.onUpdated.removeListener(listener);
+                  resolve();
+                }
+              };
+              chrome.tabs.onUpdated.addListener(listener);
+            });
+            await Promise.race([
+              completed,
+              new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 60000)),
+            ]);
+            await new Promise((r) => setTimeout(r, 700 + Math.random() * 300));
+            const [inj] = await chrome.scripting.executeScript({
+              target: { tabId: tab.id },
+              files: ["liker.js"],
+              world: "MAIN",
+            });
+            const result = inj && inj.result ? inj.result : { type: "LIKE_SKIP", reason: "open_failed" };
+            console.log("[BG/LIKER] result", result);
+            if (result?.reason === "rate_limited") {
+              console.log("[BG/LIKER] rate limited");
+              const data = await chrome.storage.local.get(["af_state"]);
+              const st = data.af_state || {};
+              const now2 = Date.now();
+              if (st.stage === 0) {
+                const pausedUntil = now2 + 20 * 60 * 1000;
+                await chrome.storage.local.set({
+                  af_state: { ...st, pausedUntil, stage: 1, consecutiveFails: 0 },
+                });
+                chrome.alarms.create("autoFollowResume", { when: pausedUntil });
+              } else if (st.stage === 1) {
+                const pausedUntil = now2 + 30 * 60 * 1000;
+                await chrome.storage.local.set({
+                  af_state: { ...st, pausedUntil, stage: 2, consecutiveFails: 0 },
+                });
+                chrome.alarms.create("autoFollowResume", { when: pausedUntil });
+              } else {
+                await chrome.storage.local.set({
+                  af_state: { running: false, pausedUntil: 0, consecutiveFails: 0, stage: st.stage || 2 },
+                });
+                chrome.alarms.clear("autoFollowResume");
+              }
+            }
+            return sendResponse(result);
+          } catch (e) {
+            console.error("[BG/LIKER] error", e);
+            return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
+          } finally {
+            if (tab?.id) chrome.tabs.remove(tab.id);
+          }
+        } else if (
+          ["START", "FOLLOW_ONE", "STOP", "AF_SET_ALARM", "AF_CLEAR_ALARM"].includes(
+            msg?.type
+          )
+        ) {
         const { auth, auth_lockUntil = 0 } = await chrome.storage.local.get([
           "auth",
           "auth_lockUntil",

--- a/bot.js
+++ b/bot.js
@@ -55,17 +55,18 @@ async function detectRateLimitOrFail(btn) {
   return { ok: false, reason: 'timeout' };
 }
 
-class Bot {
-  constructor() {
-    this.rodando = false;
-    this.perfisSeguidos = 0;
-    this.limite = 10;
-    this.overlay = null;
-    this.logOverlay = null;
-    this.countdownInterval = null;
-    this.minDelay = 120000;
-    this.maxDelay = 180000;
-  }
+  class Bot {
+    constructor() {
+      this.rodando = false;
+      this.perfisSeguidos = 0;
+      this.limite = 10;
+      this.overlay = null;
+      this.logOverlay = null;
+      this.countdownInterval = null;
+      this.minDelay = 120000;
+      this.maxDelay = 180000;
+      this.likeFirstMedia = false;
+    }
 
   criarOverlays() {
     if (!document.getElementById('autoFollowStyles')) {
@@ -232,12 +233,33 @@ class Bot {
       const username = await this.extractUsernameFromFollowButton(btn);
       btn.click();
       const result = await detectRateLimitOrFail(btn);
-      if (result.ok) {
-        this.perfisSeguidos++;
-        this.addLog(username, '✔');
-        this.atualizarOverlay(`Seguido @${username} (${this.perfisSeguidos}/${this.limite})`);
-        await setState({ consecutiveFails: 0 });
-      } else {
+        if (result.ok) {
+          this.perfisSeguidos++;
+          this.addLog(username, '✔');
+          this.atualizarOverlay(`Seguido @${username} (${this.perfisSeguidos}/${this.limite})`);
+          await setState({ consecutiveFails: 0 });
+          if (this.likeFirstMedia) {
+            try {
+              const resLike = await chrome.runtime.sendMessage({
+                type: 'LIKE_FIRST_MEDIA',
+                profileUrl: `https://www.instagram.com/${encodeURIComponent(username)}/`,
+                bringToFront: true,
+              });
+              if (resLike?.reason === 'rate_limited') {
+                const st2 = await getState();
+                if (st2.pausedUntil && st2.pausedUntil > Date.now()) {
+                  const ret = new Date(st2.pausedUntil).toLocaleTimeString();
+                  this.atualizarOverlay(`Limite detectado. Pausado até ${ret}`);
+                } else {
+                  this.atualizarOverlay('Limite detectado.');
+                }
+                return;
+              }
+            } catch (e) {
+              console.warn('[BOT] like fail', e);
+            }
+          }
+        } else {
         this.addLog(username, '✖');
         const st = await getState();
         const newFails = st.consecutiveFails + 1;
@@ -305,20 +327,21 @@ class Bot {
     this.seguirProximoUsuario();
   }
 
-  async start(limiteParam, minDelayParam, maxDelayParam) {
-    if (this.rodando) return;
-    this.rodando = true;
-    this.perfisSeguidos = 0;
-    this.limite = limiteParam || 10;
-    const min = Number(minDelayParam || 120);
-    const max = Number(maxDelayParam || 180);
-    this.minDelay = Math.min(min, max) * 1000;
-    this.maxDelay = Math.max(min, max) * 1000;
-    await setState({ running: true, pausedUntil: 0, consecutiveFails: 0 });
-    chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
-    this.criarOverlays();
-    this.seguirProximoUsuario();
-  }
+    async start(limiteParam, minDelayParam, maxDelayParam, likeFirstMedia) {
+      if (this.rodando) return;
+      this.rodando = true;
+      this.perfisSeguidos = 0;
+      this.limite = limiteParam || 10;
+      const min = Number(minDelayParam || 120);
+      const max = Number(maxDelayParam || 180);
+      this.minDelay = Math.min(min, max) * 1000;
+      this.maxDelay = Math.max(min, max) * 1000;
+      this.likeFirstMedia = !!likeFirstMedia;
+      await setState({ running: true, pausedUntil: 0, consecutiveFails: 0 });
+      chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
+      this.criarOverlays();
+      this.seguirProximoUsuario();
+    }
 
   async stop() {
     this.rodando = false;

--- a/contentscript.js
+++ b/contentscript.js
@@ -1,5 +1,5 @@
 chrome.runtime.onMessage.addListener((msg) => {
-    if (msg.action === 'start') bot.start(msg.limite, msg.minDelay, msg.maxDelay);
+    if (msg.action === 'start') bot.start(msg.limite, msg.minDelay, msg.maxDelay, msg.likeFirstMedia);
     if (msg.action === 'stop') bot.stop();
     if (msg.type === 'AF_RESUME') bot.onResume();
 });

--- a/liker.js
+++ b/liker.js
@@ -1,0 +1,156 @@
+// liker.js - injected in page main world to like first media of a profile
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const until = async (pred, { timeout = 8000, step = 120 } = {}) => {
+    const t0 = Date.now();
+    let v;
+    while (Date.now() - t0 < timeout) {
+      v = await pred();
+      if (v) return v;
+      await sleep(step);
+    }
+    return null;
+  };
+  const isVisible = (el) =>
+    el &&
+    el.isConnected &&
+    el.offsetWidth > 0 &&
+    el.offsetHeight > 0 &&
+    getComputedStyle(el).visibility !== "hidden";
+  function safeClick(el) {
+    if (!isVisible(el)) return false;
+    el.scrollIntoView({ block: "center", inline: "center" });
+    const o = { bubbles: true, cancelable: true, composed: true, view: window };
+    el.dispatchEvent(new PointerEvent("pointerover", o));
+    el.dispatchEvent(new MouseEvent("mouseover", o));
+    el.dispatchEvent(new PointerEvent("pointerdown", o));
+    el.dispatchEvent(new MouseEvent("mousedown", o));
+    el.dispatchEvent(new PointerEvent("pointerup", o));
+    el.dispatchEvent(new MouseEvent("mouseup", o));
+    try { el.click(); } catch (e) {}
+    return true;
+  }
+
+  const FAIL_TEXTS = [
+    "action blocked",
+    "try again later",
+    "tente novamente mais tarde",
+    "ação bloqueada",
+  ];
+  const POST_DELAY = 1500;
+
+  function hasRateLimitToast() {
+    const els = Array.from(document.querySelectorAll("div, span"));
+    return els.some((el) => {
+      const t = (el.innerText || "").toLowerCase();
+      return FAIL_TEXTS.some((f) => t.includes(f));
+    });
+  }
+
+  function pageUnavailable() {
+    const txt = (document.body.innerText || "").toLowerCase();
+    if (txt.includes("this page isn't available") || txt.includes("página não"))
+      return true;
+    return false;
+  }
+
+  function isPrivateWithoutFollow() {
+    const txt = (document.body.innerText || "").toLowerCase();
+    return txt.includes("this account is private") || txt.includes("esta conta é privada");
+  }
+
+  function detectMediaType(article) {
+    if (location.pathname.startsWith("/reel/")) return "reel";
+    if (article.querySelector("video")) return "video";
+    if (
+      article.querySelector("svg[aria-label*='Carrossel']") ||
+      article.querySelector("svg[aria-label*='Carousel']") ||
+      article.querySelector("button[aria-label*='Slide']")
+    )
+      return "carousel";
+    return "photo";
+  }
+
+  async function closePost(ctx) {
+    if (ctx === "modal") {
+      const btn = document.querySelector("div[role='dialog'] button[aria-label]");
+      if (btn) safeClick(btn);
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", keyCode: 27, bubbles: true })
+      );
+    } else {
+      history.back();
+    }
+    await sleep(300);
+  }
+
+  if (pageUnavailable()) {
+    return { type: "LIKE_SKIP", reason: "open_failed" };
+  }
+  if (isPrivateWithoutFollow()) {
+    return { type: "LIKE_SKIP", reason: "no_media" };
+  }
+
+  const anchor = Array.from(
+    document.querySelectorAll("article a[href*='/p/'], article a[href*='/reel/']")
+  ).find(isVisible);
+  if (!anchor) return { type: "LIKE_SKIP", reason: "no_media" };
+  safeClick(anchor);
+
+  const opened = await until(() => {
+    const dlg = document.querySelector("div[role='dialog'] article");
+    if (dlg) return { article: dlg, ctx: "modal" };
+    if (location.pathname.startsWith("/p/") || location.pathname.startsWith("/reel/")) {
+      const art = document.querySelector("main article");
+      if (art) return { article: art, ctx: "page" };
+    }
+    return null;
+  });
+  if (!opened) return { type: "LIKE_SKIP", reason: "open_failed" };
+
+  const { article, ctx } = opened;
+  const mediaType = detectMediaType(article);
+
+  const findBtn = () =>
+    Array.from(article.querySelectorAll("button[aria-label][aria-pressed]")).find((b) => {
+      const l = (b.getAttribute("aria-label") || "").toLowerCase();
+      return /curtir|like|descurtir|unlike/.test(l);
+    });
+
+  let btn = findBtn();
+  if (!btn) {
+    await closePost(ctx);
+    return { type: "LIKE_SKIP", reason: "like_button_not_found" };
+  }
+  if (btn.getAttribute("aria-pressed") === "true") {
+    await closePost(ctx);
+    return { type: "LIKE_DONE", mediaType, already: true };
+  }
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    safeClick(btn);
+    const changed = await until(() => {
+      if (hasRateLimitToast()) return "rate_limited";
+      return btn.getAttribute("aria-pressed") === "true";
+    });
+    if (changed === "rate_limited") {
+      await closePost(ctx);
+      return { type: "LIKE_SKIP", reason: "rate_limited" };
+    }
+    if (changed) {
+      await sleep(POST_DELAY);
+      await closePost(ctx);
+      return { type: "LIKE_DONE", mediaType };
+    }
+    btn = findBtn();
+    if (!btn) break;
+    if (btn.getAttribute("aria-pressed") === "true") {
+      await sleep(POST_DELAY);
+      await closePost(ctx);
+      return { type: "LIKE_DONE", mediaType };
+    }
+  }
+  await closePost(ctx);
+  return { type: "LIKE_SKIP", reason: "state_not_changed" };
+})();
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,12 +3,13 @@
   "name": "Instagram Auto Follow RSX V1",
   "version": "1.0.0",
   "description": "Segue automaticamente perfis no modal de seguidores com limite e delay aleatório.",
-  "permissions": [
-    "activeTab",
-    "storage",
-    "tabs",
-    "alarms"
-  ],
+    "permissions": [
+      "activeTab",
+      "storage",
+      "tabs",
+      "alarms",
+      "scripting"
+    ],
   "host_permissions": [
     "https://www.instagram.com/*"
   ],

--- a/popup.html
+++ b/popup.html
@@ -27,6 +27,8 @@
     <label for="maxDelay">Delay máximo (s):</label>
     <input type="number" id="maxDelay" min="0" value="180">
 
+    <label><input type="checkbox" id="likeFirstMedia"> Curtir a primeira mídia após seguir</label>
+
     <button id="startBtn">Iniciar</button>
     <button id="stopBtn">Parar</button>
     <button id="logoutBtn">Sair</button>

--- a/popup.js
+++ b/popup.js
@@ -16,14 +16,16 @@ document.addEventListener('DOMContentLoaded', () => {
     refreshStatus();
   }
 
-  chrome.storage.sync.get(['minDelay', 'maxDelay', 'limite'], (data) => {
-    const quantidade = document.getElementById('quantidade');
-    const minDelay = document.getElementById('minDelay');
-    const maxDelay = document.getElementById('maxDelay');
-    if (quantidade) quantidade.value = data.limite || 10;
-    if (minDelay) minDelay.value = data.minDelay || 120;
-    if (maxDelay) maxDelay.value = data.maxDelay || 180;
-  });
+    chrome.storage.sync.get(['minDelay', 'maxDelay', 'limite', 'likeFirstMedia'], (data) => {
+      const quantidade = document.getElementById('quantidade');
+      const minDelay = document.getElementById('minDelay');
+      const maxDelay = document.getElementById('maxDelay');
+      const likeFirst = document.getElementById('likeFirstMedia');
+      if (quantidade) quantidade.value = data.limite || 10;
+      if (minDelay) minDelay.value = data.minDelay || 120;
+      if (maxDelay) maxDelay.value = data.maxDelay || 180;
+      if (likeFirst) likeFirst.checked = data.likeFirstMedia || false;
+    });
 
   function refreshStatus() {
     chrome.storage.local.get('af_state', (data) => {
@@ -55,11 +57,12 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   document.getElementById('startBtn')?.addEventListener('click', () => {
-    const limite = parseInt(document.getElementById('quantidade')?.value) || 10;
-    const minDelay = parseInt(document.getElementById('minDelay')?.value) || 120;
-    const maxDelay = parseInt(document.getElementById('maxDelay')?.value) || 180;
+      const limite = parseInt(document.getElementById('quantidade')?.value) || 10;
+      const minDelay = parseInt(document.getElementById('minDelay')?.value) || 120;
+      const maxDelay = parseInt(document.getElementById('maxDelay')?.value) || 180;
+      const likeFirst = document.getElementById('likeFirstMedia')?.checked || false;
 
-    chrome.storage.sync.set({ minDelay, maxDelay, limite });
+      chrome.storage.sync.set({ minDelay, maxDelay, limite, likeFirstMedia: likeFirst });
 
     chrome.storage.local.get('af_state', (data) => {
       const st = data.af_state || {};
@@ -67,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
         { af_state: { ...st, running: true, pausedUntil: 0, consecutiveFails: 0 } },
         () => {
           chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
-          sendMessageToActiveTab({ action: 'start', limite, minDelay, maxDelay });
+            sendMessageToActiveTab({ action: 'start', limite, minDelay, maxDelay, likeFirstMedia: likeFirst });
           refreshStatus();
         }
       );


### PR DESCRIPTION
## Summary
- add page-side liker script to open first post, like and detect rate limits
- handle LIKE_FIRST_MEDIA in background with backoff and tab management
- expose 'like first media after follow' toggle and wire bot to use it

## Testing
- `node --check liker.js`
- `node --check background.js`
- `node --check bot.js`
- `node --check contentscript.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8ecb71fd48326b3f1b692751a55ba