### PR TITLE
feat: refactor liker handler

### DIFF
--- a/background.js
+++ b/background.js
@@ -161,90 +161,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return sendResponse({ ok: !!authorized });
       }
 
-        if (msg?.type === "LIKE_FIRST_MEDIA") {
-          const { auth, auth_lockUntil = 0, af_state = {} } = await chrome.storage.local.get([
-            "auth",
-            "auth_lockUntil",
-            "af_state",
-          ]);
-          const authorized = isAuthorized(auth, auth_lockUntil, now);
-          const paused = af_state.pausedUntil && af_state.pausedUntil > now;
-          const finished = af_state.stage >= 2;
-          if (!authorized || paused || finished) {
-            return sendResponse({ ok: false, error: "UNAUTHORIZED" });
-          }
-
-          const profileUrl = msg.profileUrl;
-          if (!profileUrl) return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
-          console.log("[BG/LIKER] requesting like for", profileUrl);
-
-          let tab;
-          try {
-            tab = await new Promise((resolve) =>
-              chrome.tabs.create({ url: profileUrl, active: true }, resolve)
-            );
-          } catch (e) {
-            console.error("[BG/LIKER] create tab fail", e);
-            return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
-          }
-
-          try {
-            await chrome.windows.update(tab.windowId, { focused: true });
-            await chrome.tabs.update(tab.id, { active: true });
-
-            const completed = new Promise((resolve) => {
-              const listener = (tid, info) => {
-                if (tid === tab.id && info.status === "complete") {
-                  chrome.tabs.onUpdated.removeListener(listener);
-                  resolve();
-                }
-              };
-              chrome.tabs.onUpdated.addListener(listener);
-            });
-            await Promise.race([
-              completed,
-              new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 60000)),
-            ]);
-            await new Promise((r) => setTimeout(r, 700 + Math.random() * 300));
-            const [inj] = await chrome.scripting.executeScript({
-              target: { tabId: tab.id },
-              files: ["liker.js"],
-              world: "MAIN",
-            });
-            const result = inj && inj.result ? inj.result : { type: "LIKE_SKIP", reason: "open_failed" };
-            console.log("[BG/LIKER] result", result);
-            if (result?.reason === "rate_limited") {
-              console.log("[BG/LIKER] rate limited");
-              const data = await chrome.storage.local.get(["af_state"]);
-              const st = data.af_state || {};
-              const now2 = Date.now();
-              if (st.stage === 0) {
-                const pausedUntil = now2 + 20 * 60 * 1000;
-                await chrome.storage.local.set({
-                  af_state: { ...st, pausedUntil, stage: 1, consecutiveFails: 0 },
-                });
-                chrome.alarms.create("autoFollowResume", { when: pausedUntil });
-              } else if (st.stage === 1) {
-                const pausedUntil = now2 + 30 * 60 * 1000;
-                await chrome.storage.local.set({
-                  af_state: { ...st, pausedUntil, stage: 2, consecutiveFails: 0 },
-                });
-                chrome.alarms.create("autoFollowResume", { when: pausedUntil });
-              } else {
-                await chrome.storage.local.set({
-                  af_state: { running: false, pausedUntil: 0, consecutiveFails: 0, stage: st.stage || 2 },
-                });
-                chrome.alarms.clear("autoFollowResume");
-              }
-            }
-            return sendResponse(result);
-          } catch (e) {
-            console.error("[BG/LIKER] error", e);
-            return sendResponse({ type: "LIKE_SKIP", reason: "open_failed" });
-          } finally {
-            if (tab?.id) chrome.tabs.remove(tab.id);
-          }
-        } else if (
+        if (
           ["START", "FOLLOW_ONE", "STOP", "AF_SET_ALARM", "AF_CLEAR_ALARM"].includes(
             msg?.type
           )
@@ -285,6 +202,100 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   })();
   return true;
 });
+
+// BEGIN LIKER HANDLER (do not remove this comment)
+(function attachLikerHandler(){
+  if (attachLikerHandler._bound) return; // idempotente
+
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    (async () => {
+      try {
+        if (msg?.type !== "LIKE_FIRST_MEDIA" && msg?.type !== "LIKE_REQUEST") {
+          return sendResponse({ ok:false, passthrough:true });
+        }
+
+        // Gate de autorização — use CAN_RUN se existir
+        let authorized = true;
+        try {
+          const gate = await chrome.runtime.sendMessage({ type:"CAN_RUN" });
+          authorized = !!gate?.ok;
+        } catch(_){
+          const { auth, auth_lockUntil=0 } = await chrome.storage.local.get(["auth","auth_lockUntil"]);
+          const now = Date.now();
+          authorized = (!auth_lockUntil || auth_lockUntil <= now)
+                    && auth?.state === "AUTH"
+                    && (!auth?.exp || auth.exp > now);
+        }
+        if (!authorized) return sendResponse({ ok:false, error:"UNAUTHORIZED" });
+
+        // Normaliza entrada
+        let profileUrl = msg?.profileUrl || null;
+        if (!profileUrl && msg?.type === "LIKE_REQUEST" && msg.username) {
+          profileUrl = `https://www.instagram.com/${msg.username}/`;
+        }
+        if (!profileUrl) {
+          // tentar deduzir da aba ativa
+          const [tab] = await chrome.tabs.query({active:true, currentWindow:true});
+          if (!tab?.url) return sendResponse({ ok:false, error:"NO_ACTIVE_TAB" });
+          const u = new URL(tab.url);
+          const p = u.pathname.split("/").filter(Boolean);
+          if (!p[0] || p[0]==="p" || p[0]==="reel")
+            return sendResponse({ ok:false, error:"NOT_ON_PROFILE" });
+          profileUrl = `https://www.instagram.com/${p[0]}/`;
+        }
+
+        // Abrir/ativar aba e focar janela
+        const tab = await new Promise(res => chrome.tabs.create({ url: profileUrl, active: true }, res));
+        if (!tab?.id) return sendResponse({ ok:false, error:"TAB_CREATE_FAILED" });
+        if (tab.windowId) await chrome.windows.update(tab.windowId, { focused: true });
+
+        // Esperar carregar COMPLETO
+        await new Promise(resolve => {
+          const onUpdated = (id, info) => {
+            if (id === tab.id && info.status === "complete") {
+              chrome.tabs.onUpdated.removeListener(onUpdated);
+              resolve();
+            }
+          };
+          chrome.tabs.onUpdated.addListener(onUpdated);
+        });
+        await new Promise(r=>setTimeout(r,800)); // hidratação
+
+        // Injetar liker no MAIN
+        await chrome.scripting.executeScript({ target:{ tabId: tab.id }, files:['liker.js'], world:'MAIN' });
+
+        // Aguardar resposta do liker
+        let done=false;
+        const timer = setTimeout(()=>{
+          if (!done) {
+            chrome.runtime.onMessage.removeListener(onMsg);
+            sendResponse({ ok:false, type:"LIKE_SKIP", reason:"timeout" });
+          }
+        }, 60000);
+
+        function onMsg(m, snd){
+          if (snd?.tab?.id !== tab.id) return;
+          if (m?.type === "LIKE_DONE") {
+            done = true; clearTimeout(timer);
+            chrome.runtime.onMessage.removeListener(onMsg);
+            return sendResponse({ ok:true, ...m });
+          }
+          if (m?.type === "LIKE_SKIP") {
+            done = true; clearTimeout(timer);
+            chrome.runtime.onMessage.removeListener(onMsg);
+            return sendResponse({ ok:false, ...m });
+          }
+        }
+        chrome.runtime.onMessage.addListener(onMsg);
+      } catch(e){
+        console.error("[BG/LIKER] exception:", e);
+        sendResponse({ ok:false, type:"LIKE_SKIP", reason:"exception", detail:String(e?.message||e) });
+      }
+    })();
+    return true; // manter a porta aberta
+  });
+})();
+// END LIKER HANDLER (do not remove this comment)
 
 chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === "autoFollowResume") {

--- a/liker.js
+++ b/liker.js
@@ -1,156 +1,90 @@
-// liker.js - injected in page main world to like first media of a profile
 (async () => {
-  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-  const until = async (pred, { timeout = 8000, step = 120 } = {}) => {
-    const t0 = Date.now();
-    let v;
-    while (Date.now() - t0 < timeout) {
-      v = await pred();
-      if (v) return v;
-      await sleep(step);
-    }
+  const sleep = (ms)=>new Promise(r=>setTimeout(r,ms));
+  const until = async (pred, {timeout=8000, step=120}={})=>{
+    const t0=Date.now(); while(Date.now()-t0<timeout){ const v=await pred(); if(v) return v; await sleep(step); }
     return null;
   };
-  const isVisible = (el) =>
-    el &&
-    el.isConnected &&
-    el.offsetWidth > 0 &&
-    el.offsetHeight > 0 &&
-    getComputedStyle(el).visibility !== "hidden";
-  function safeClick(el) {
-    if (!isVisible(el)) return false;
-    el.scrollIntoView({ block: "center", inline: "center" });
-    const o = { bubbles: true, cancelable: true, composed: true, view: window };
-    el.dispatchEvent(new PointerEvent("pointerover", o));
-    el.dispatchEvent(new MouseEvent("mouseover", o));
-    el.dispatchEvent(new PointerEvent("pointerdown", o));
-    el.dispatchEvent(new MouseEvent("mousedown", o));
-    el.dispatchEvent(new PointerEvent("pointerup", o));
-    el.dispatchEvent(new MouseEvent("mouseup", o));
-    try { el.click(); } catch (e) {}
+  const isVisible = el => el && el.isConnected && el.offsetWidth>0 && el.offsetHeight>0 && getComputedStyle(el).visibility!=='hidden';
+  const log = (...a)=>{ try{ console.log("[LIKER]", ...a);}catch{} };
+
+  function safeClick(el){
+    if(!isVisible(el)) return false;
+    el.scrollIntoView({block:'center', inline:'center'});
+    const o={bubbles:true, cancelable:true, composed:true, view:window};
+    try{ el.dispatchEvent(new PointerEvent('pointerover', o)); }catch{}
+    try{ el.dispatchEvent(new MouseEvent('mouseover', o)); }catch{}
+    try{ el.dispatchEvent(new PointerEvent('pointerdown', o)); }catch{}
+    try{ el.dispatchEvent(new MouseEvent('mousedown', o)); }catch{}
+    try{ el.dispatchEvent(new PointerEvent('pointerup', o)); }catch{}
+    try{ el.dispatchEvent(new MouseEvent('mouseup', o)); }catch{}
+    try{ el.click(); }catch{}
     return true;
   }
+  const send = (type, reason)=> chrome.runtime.sendMessage({ type, reason });
 
-  const FAIL_TEXTS = [
-    "action blocked",
-    "try again later",
-    "tente novamente mais tarde",
-    "ação bloqueada",
-  ];
-  const POST_DELAY = 1500;
+  try{
+    // Fechar intersticiais básicos
+    (()=>{
+      const texts=['Fechar','Close','Agora não','Not now','Aceitar','Accept','Allow','Ver foto','See photo'];
+      [...document.querySelectorAll('button,[role="button"]')].forEach(b=>{
+        const t=(b.ariaLabel||b.innerText||'').trim();
+        if(texts.some(x=>t.includes(x))) { try{ b.click(); }catch{} }
+      });
+    })();
 
-  function hasRateLimitToast() {
-    const els = Array.from(document.querySelectorAll("div, span"));
-    return els.some((el) => {
-      const t = (el.innerText || "").toLowerCase();
-      return FAIL_TEXTS.some((f) => t.includes(f));
-    });
-  }
-
-  function pageUnavailable() {
-    const txt = (document.body.innerText || "").toLowerCase();
-    if (txt.includes("this page isn't available") || txt.includes("página não"))
-      return true;
-    return false;
-  }
-
-  function isPrivateWithoutFollow() {
-    const txt = (document.body.innerText || "").toLowerCase();
-    return txt.includes("this account is private") || txt.includes("esta conta é privada");
-  }
-
-  function detectMediaType(article) {
-    if (location.pathname.startsWith("/reel/")) return "reel";
-    if (article.querySelector("video")) return "video";
-    if (
-      article.querySelector("svg[aria-label*='Carrossel']") ||
-      article.querySelector("svg[aria-label*='Carousel']") ||
-      article.querySelector("button[aria-label*='Slide']")
-    )
-      return "carousel";
-    return "photo";
-  }
-
-  async function closePost(ctx) {
-    if (ctx === "modal") {
-      const btn = document.querySelector("div[role='dialog'] button[aria-label]");
-      if (btn) safeClick(btn);
-      document.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Escape", keyCode: 27, bubbles: true })
-      );
-    } else {
-      history.back();
+    // Achar 1ª mídia no grid do perfil
+    window.scrollTo(0,0); await sleep(200);
+    let anchors=[...document.querySelectorAll('article a[href*="/p/"], article a[href*="/reel/"]')].filter(isVisible);
+    if(!anchors.length){ window.scrollTo(0,600); await sleep(250);
+      anchors=[...document.querySelectorAll('article a[href*="/p/"], article a[href*="/reel/"]')].filter(isVisible);
     }
-    await sleep(300);
-  }
+    const first=anchors[0];
+    if(!first){ log("no media"); return send("LIKE_SKIP","no_media"); }
 
-  if (pageUnavailable()) {
-    return { type: "LIKE_SKIP", reason: "open_failed" };
-  }
-  if (isPrivateWithoutFollow()) {
-    return { type: "LIKE_SKIP", reason: "no_media" };
-  }
-
-  const anchor = Array.from(
-    document.querySelectorAll("article a[href*='/p/'], article a[href*='/reel/']")
-  ).find(isVisible);
-  if (!anchor) return { type: "LIKE_SKIP", reason: "no_media" };
-  safeClick(anchor);
-
-  const opened = await until(() => {
-    const dlg = document.querySelector("div[role='dialog'] article");
-    if (dlg) return { article: dlg, ctx: "modal" };
-    if (location.pathname.startsWith("/p/") || location.pathname.startsWith("/reel/")) {
-      const art = document.querySelector("main article");
-      if (art) return { article: art, ctx: "page" };
+    // Abrir mídia
+    safeClick(first);
+    let mode="modal";
+    const modal = await until(()=>document.querySelector('[role="dialog"] article'));
+    if(!modal){
+      mode="route";
+      const ok = await until(()=>/^(\/p\/|\/reel\/)/.test(location.pathname));
+      if(!ok){ log("open_failed"); return send("LIKE_SKIP","open_failed"); }
     }
-    return null;
-  });
-  if (!opened) return { type: "LIKE_SKIP", reason: "open_failed" };
+    const ctx = mode==="modal" ? document.querySelector('[role="dialog"]') : document;
 
-  const { article, ctx } = opened;
-  const mediaType = detectMediaType(article);
-
-  const findBtn = () =>
-    Array.from(article.querySelectorAll("button[aria-label][aria-pressed]")).find((b) => {
-      const l = (b.getAttribute("aria-label") || "").toLowerCase();
-      return /curtir|like|descurtir|unlike/.test(l);
-    });
-
-  let btn = findBtn();
-  if (!btn) {
-    await closePost(ctx);
-    return { type: "LIKE_SKIP", reason: "like_button_not_found" };
-  }
-  if (btn.getAttribute("aria-pressed") === "true") {
-    await closePost(ctx);
-    return { type: "LIKE_DONE", mediaType, already: true };
-  }
-
-  for (let attempt = 0; attempt < 2; attempt++) {
-    safeClick(btn);
-    const changed = await until(() => {
-      if (hasRateLimitToast()) return "rate_limited";
-      return btn.getAttribute("aria-pressed") === "true";
-    });
-    if (changed === "rate_limited") {
-      await closePost(ctx);
-      return { type: "LIKE_SKIP", reason: "rate_limited" };
+    function findLikeBtn(){
+      const article = ctx.querySelector('article') || ctx;
+      const pressed   = article.querySelector('button[aria-pressed="true"]');
+      const unpressed = article.querySelector('button[aria-pressed="false"]');
+      const likeLbl   = article.querySelector('button[aria-label*="Curtir" i],button[aria-label*="Like" i]');
+      const unlikeLbl = article.querySelector('button[aria-label*="Descurtir" i],button[aria-label*="Unlike" i]');
+      return { article, pressed, unpressed, likeLbl, unlikeLbl };
     }
-    if (changed) {
-      await sleep(POST_DELAY);
-      await closePost(ctx);
-      return { type: "LIKE_DONE", mediaType };
+    function alreadyLiked(s){ return !!(s.pressed || s.unlikeLbl); }
+
+    let s = findLikeBtn();
+    if(!(s.pressed||s.unpressed||s.likeLbl||s.unlikeLbl)){
+      log("like_button_not_found"); return send("LIKE_SKIP","like_button_not_found");
     }
-    btn = findBtn();
-    if (!btn) break;
-    if (btn.getAttribute("aria-pressed") === "true") {
-      await sleep(POST_DELAY);
-      await closePost(ctx);
-      return { type: "LIKE_DONE", mediaType };
+    if(alreadyLiked(s)){ log("already liked"); if(mode==="modal") ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click(); return send("LIKE_DONE"); }
+
+    async function clickAndConfirm(){
+      let f = findLikeBtn(); const btn = f.pressed||f.unpressed||f.likeLbl||f.unlikeLbl;
+      if(!btn) return false;
+      safeClick(btn); await sleep(300);
+      const ok = await until(()=> { const g=findLikeBtn(); return alreadyLiked(g); }, {timeout:8000, step:150});
+      return !!ok;
     }
+
+    let ok = await clickAndConfirm();
+    if(!ok){ log("retrying..."); await sleep(500); ok = await clickAndConfirm(); }
+    if(!ok){ log("state_not_changed"); return send("LIKE_SKIP","state_not_changed"); }
+
+    if(mode==="modal") ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click();
+    log("LIKE_DONE"); return send("LIKE_DONE");
+  }catch(e){
+    console.error("[LIKER] exception", e);
+    return send("LIKE_SKIP","exception");
   }
-  await closePost(ctx);
-  return { type: "LIKE_SKIP", reason: "state_not_changed" };
 })();
 


### PR DESCRIPTION
## Summary
- replace liker.js with streamlined script for page-world execution
- reimplement background liker handler with auth gating and tab lifecycle management

## Testing
- `node --check background.js`
- `node --check liker.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9cb93f6bc832697988bf4d290c466