### PR TITLE
feat: improve first media like flow

### DIFF
--- a/background.js
+++ b/background.js
@@ -37,9 +37,18 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     (async () => {
+      const t0 = Date.now();
+      let likeTab = null;
+      const finalize = (resp) => {
+        try {
+          if (likeTab?.id) chrome.tabs.remove(likeTab.id);
+        } catch {}
+        resp.tookMs = Date.now() - t0;
+        sendResponse(resp);
+      };
       try {
         if (msg?.type !== "LIKE_FIRST_MEDIA" && msg?.type !== "LIKE_REQUEST") {
-          return sendResponse({ ok:false, passthrough:true });
+          return finalize({ ok:false, passthrough:true });
         }
 
         // Normaliza entrada
@@ -50,23 +59,23 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         if (!profileUrl) {
           // tentar deduzir da aba ativa
           const [tab] = await chrome.tabs.query({active:true, currentWindow:true});
-          if (!tab?.url) return sendResponse({ ok:false, error:"NO_ACTIVE_TAB" });
+          if (!tab?.url) return finalize({ ok:false, error:"NO_ACTIVE_TAB" });
           const u = new URL(tab.url);
           const p = u.pathname.split("/").filter(Boolean);
           if (!p[0] || p[0]==="p" || p[0]==="reel")
-            return sendResponse({ ok:false, error:"NOT_ON_PROFILE" });
+            return finalize({ ok:false, error:"NOT_ON_PROFILE" });
           profileUrl = `https://www.instagram.com/${p[0]}/`;
         }
 
         // Abrir/ativar aba e focar janela
-        const tab = await new Promise(res => chrome.tabs.create({ url: profileUrl, active: true }, res));
-        if (!tab?.id) return sendResponse({ ok:false, error:"TAB_CREATE_FAILED" });
-        if (tab.windowId) await chrome.windows.update(tab.windowId, { focused: true });
+        likeTab = await new Promise(res => chrome.tabs.create({ url: profileUrl, active: true }, res));
+        if (!likeTab?.id) return finalize({ ok:false, error:"TAB_CREATE_FAILED" });
+        if (likeTab.windowId) await chrome.windows.update(likeTab.windowId, { focused: true });
 
         // Esperar carregar COMPLETO
         await new Promise(resolve => {
           const onUpdated = (id, info) => {
-            if (id === tab.id && info.status === "complete") {
+            if (id === likeTab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(onUpdated);
               resolve();
             }
@@ -76,34 +85,33 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         await new Promise(r=>setTimeout(r,800)); // hidratação
 
         // Injetar liker no MAIN
-        await chrome.scripting.executeScript({ target:{ tabId: tab.id }, files:['liker.js'], world:'MAIN' });
+        await chrome.scripting.executeScript({ target:{ tabId: likeTab.id }, files:['liker.js'], world:'MAIN' });
 
         // Aguardar resposta do liker
         let done=false;
         const timer = setTimeout(()=>{
           if (!done) {
             chrome.runtime.onMessage.removeListener(onMsg);
-            sendResponse({ ok:false, type:"LIKE_SKIP", reason:"timeout" });
+            finalize({ ok:false, type:"LIKE_SKIP", reason:"timeout" });
           }
         }, 60000);
 
         function onMsg(m, snd){
-          if (snd?.tab?.id !== tab.id) return;
+          if (snd?.tab?.id !== likeTab.id) return;
           if (m?.type === "LIKE_DONE") {
             done = true; clearTimeout(timer);
             chrome.runtime.onMessage.removeListener(onMsg);
-            return sendResponse({ ok:true, ...m });
-          }
-          if (m?.type === "LIKE_SKIP") {
+            finalize({ ok:true, type:"LIKE_DONE", mode:m.mode });
+          } else if (m?.type === "LIKE_SKIP") {
             done = true; clearTimeout(timer);
             chrome.runtime.onMessage.removeListener(onMsg);
-            return sendResponse({ ok:false, ...m });
+            finalize({ ok:false, type:"LIKE_SKIP", mode:m.mode, reason:m.reason });
           }
         }
         chrome.runtime.onMessage.addListener(onMsg);
       } catch(e){
         console.error("[BG/LIKER] exception:", e);
-        sendResponse({ ok:false, type:"LIKE_SKIP", reason:"exception", detail:String(e?.message||e) });
+        finalize({ ok:false, type:"LIKE_SKIP", reason:"exception", detail:String(e?.message||e) });
       }
     })();
     return true; // manter a porta aberta

--- a/liker.js
+++ b/liker.js
@@ -1,90 +1,162 @@
 (async () => {
-  const sleep = (ms)=>new Promise(r=>setTimeout(r,ms));
-  const until = async (pred, {timeout=8000, step=120}={})=>{
-    const t0=Date.now(); while(Date.now()-t0<timeout){ const v=await pred(); if(v) return v; await sleep(step); }
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const until = async (pred, { timeout = 8000, step = 120 } = {}) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeout) {
+      const v = await pred();
+      if (v) return v;
+      await sleep(step);
+    }
     return null;
   };
-  const isVisible = el => el && el.isConnected && el.offsetWidth>0 && el.offsetHeight>0 && getComputedStyle(el).visibility!=='hidden';
-  const log = (...a)=>{ try{ console.log("[LIKER]", ...a);}catch{} };
+  const isVisible = (el) =>
+    el && el.isConnected && el.offsetWidth > 0 && el.offsetHeight > 0 &&
+    getComputedStyle(el).visibility !== 'hidden';
+  const log = (...a) => { try { console.log('[LIKER]', ...a); } catch {} };
 
-  function safeClick(el){
-    if(!isVisible(el)) return false;
-    el.scrollIntoView({block:'center', inline:'center'});
-    const o={bubbles:true, cancelable:true, composed:true, view:window};
-    try{ el.dispatchEvent(new PointerEvent('pointerover', o)); }catch{}
-    try{ el.dispatchEvent(new MouseEvent('mouseover', o)); }catch{}
-    try{ el.dispatchEvent(new PointerEvent('pointerdown', o)); }catch{}
-    try{ el.dispatchEvent(new MouseEvent('mousedown', o)); }catch{}
-    try{ el.dispatchEvent(new PointerEvent('pointerup', o)); }catch{}
-    try{ el.dispatchEvent(new MouseEvent('mouseup', o)); }catch{}
-    try{ el.click(); }catch{}
+  function safeClick(el) {
+    if (!isVisible(el)) return false;
+    el.scrollIntoView({ block: 'center', inline: 'center' });
+    const o = { bubbles: true, cancelable: true, composed: true, view: window };
+    try { el.dispatchEvent(new PointerEvent('pointerover', o)); } catch {}
+    try { el.dispatchEvent(new MouseEvent('mouseover', o)); } catch {}
+    try { el.dispatchEvent(new PointerEvent('pointerdown', o)); } catch {}
+    try { el.dispatchEvent(new MouseEvent('mousedown', o)); } catch {}
+    try { el.dispatchEvent(new PointerEvent('pointerup', o)); } catch {}
+    try { el.dispatchEvent(new MouseEvent('mouseup', o)); } catch {}
+    try { el.click(); } catch {}
     return true;
   }
-  const send = (type, reason)=> chrome.runtime.sendMessage({ type, reason });
 
-  try{
-    // Fechar intersticiais básicos
-    (()=>{
-      const texts=['Fechar','Close','Agora não','Not now','Aceitar','Accept','Allow','Ver foto','See photo'];
-      [...document.querySelectorAll('button,[role="button"]')].forEach(b=>{
-        const t=(b.ariaLabel||b.innerText||'').trim();
-        if(texts.some(x=>t.includes(x))) { try{ b.click(); }catch{} }
+  const t0 = Date.now();
+  let mode = undefined;
+  const send = (type, reason) => {
+    const payload = { type, mode, tookMs: Date.now() - t0 };
+    if (reason) payload.reason = reason;
+    chrome.runtime.sendMessage(payload);
+  };
+
+  async function waitProfileGrid() {
+    return !!(await until(() => {
+      const article = document.querySelector('article');
+      if (!article) return null;
+      const tile = article.querySelector('a[href*="/p/"], a[href*="/reel/"], [role="link"]');
+      return tile ? article : null;
+    }, { timeout: 15000, step: 300 }));
+  }
+
+  async function findFirstMediaAnchor() {
+    const attempts = 3;
+    for (let i = 0; i < attempts; i++) {
+      let anchors = [...document.querySelectorAll('article a[href*="/p/"], article a[href*="/reel/"]')].filter(isVisible);
+      if (anchors.length) return anchors[0];
+
+      anchors = [...document.querySelectorAll('article [role="link"]')].filter(el => {
+        if (!isVisible(el)) return false;
+        return !!el.querySelector('img,canvas,video,svg[aria-label*="Reels" i]');
+      });
+      if (anchors.length) return anchors[0];
+
+      window.scrollBy(0, 800);
+      await sleep(300);
+    }
+    return null;
+  }
+
+  try {
+    // Fechar intersticiais
+    (() => {
+      const texts = [
+        'Fechar', 'Close', 'Agora não', 'Not now', 'Aceitar', 'Accept', 'Allow',
+        'Abrir app', 'Open app', 'Ver foto', 'See photo', 'Talvez depois', 'Maybe later'
+      ];
+      [...document.querySelectorAll('button,[role="button"]')].forEach(b => {
+        const t = (b.ariaLabel || b.innerText || '').trim().toLowerCase();
+        if (texts.some(x => t.includes(x.toLowerCase()))) {
+          try { b.click(); } catch {}
+        }
       });
     })();
 
-    // Achar 1ª mídia no grid do perfil
-    window.scrollTo(0,0); await sleep(200);
-    let anchors=[...document.querySelectorAll('article a[href*="/p/"], article a[href*="/reel/"]')].filter(isVisible);
-    if(!anchors.length){ window.scrollTo(0,600); await sleep(250);
-      anchors=[...document.querySelectorAll('article a[href*="/p/"], article a[href*="/reel/"]')].filter(isVisible);
+    const gridReady = await waitProfileGrid();
+    if (!gridReady) {
+      log('no media');
+      return send('LIKE_SKIP', 'no_media');
     }
-    const first=anchors[0];
-    if(!first){ log("no media"); return send("LIKE_SKIP","no_media"); }
 
-    // Abrir mídia
-    safeClick(first);
-    let mode="modal";
-    const modal = await until(()=>document.querySelector('[role="dialog"] article'));
-    if(!modal){
-      mode="route";
-      const ok = await until(()=>/^(\/p\/|\/reel\/)/.test(location.pathname));
-      if(!ok){ log("open_failed"); return send("LIKE_SKIP","open_failed"); }
+    window.scrollTo(0, 0);
+    await sleep(200);
+
+    const anchor = await findFirstMediaAnchor();
+    if (!anchor) {
+      log('no media');
+      return send('LIKE_SKIP', 'no_media');
     }
-    const ctx = mode==="modal" ? document.querySelector('[role="dialog"]') : document;
 
-    function findLikeBtn(){
+    safeClick(anchor);
+
+    mode = 'modal';
+    const modal = await until(() => document.querySelector('[role="dialog"] article'), { timeout: 10000, step: 200 });
+    if (!modal) {
+      mode = 'route';
+      const opened = await until(() => /^(\/p\/|\/reel\/)/.test(location.pathname), { timeout: 10000, step: 200 });
+      if (!opened) {
+        log('open_failed');
+        return send('LIKE_SKIP', 'open_failed');
+      }
+    }
+    const ctx = mode === 'modal' ? document.querySelector('[role="dialog"]') : document;
+
+    function findLikeBtn() {
       const article = ctx.querySelector('article') || ctx;
-      const pressed   = article.querySelector('button[aria-pressed="true"]');
+      const pressed = article.querySelector('button[aria-pressed="true"]');
       const unpressed = article.querySelector('button[aria-pressed="false"]');
-      const likeLbl   = article.querySelector('button[aria-label*="Curtir" i],button[aria-label*="Like" i]');
+      const likeLbl = article.querySelector('button[aria-label*="Curtir" i],button[aria-label*="Like" i]');
       const unlikeLbl = article.querySelector('button[aria-label*="Descurtir" i],button[aria-label*="Unlike" i]');
       return { article, pressed, unpressed, likeLbl, unlikeLbl };
     }
-    function alreadyLiked(s){ return !!(s.pressed || s.unlikeLbl); }
+    const alreadyLiked = (s) => !!(s.pressed || s.unlikeLbl);
 
-    let s = findLikeBtn();
-    if(!(s.pressed||s.unpressed||s.likeLbl||s.unlikeLbl)){
-      log("like_button_not_found"); return send("LIKE_SKIP","like_button_not_found");
+    let state = findLikeBtn();
+    if (!(state.pressed || state.unpressed || state.likeLbl || state.unlikeLbl)) {
+      log('like_button_not_found');
+      return send('LIKE_SKIP', 'like_button_not_found');
     }
-    if(alreadyLiked(s)){ log("already liked"); if(mode==="modal") ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click(); return send("LIKE_DONE"); }
+    if (alreadyLiked(state)) {
+      if (mode === 'modal') ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click();
+      return send('LIKE_DONE');
+    }
 
-    async function clickAndConfirm(){
-      let f = findLikeBtn(); const btn = f.pressed||f.unpressed||f.likeLbl||f.unlikeLbl;
-      if(!btn) return false;
-      safeClick(btn); await sleep(300);
-      const ok = await until(()=> { const g=findLikeBtn(); return alreadyLiked(g); }, {timeout:8000, step:150});
+    async function clickAndConfirm() {
+      let f = findLikeBtn();
+      const btn = f.unpressed || f.likeLbl || f.pressed || f.unlikeLbl;
+      if (!btn) return false;
+      safeClick(btn);
+      await sleep(300);
+      const ok = await until(() => {
+        const g = findLikeBtn();
+        return alreadyLiked(g);
+      }, { timeout: 8000, step: 150 });
       return !!ok;
     }
 
     let ok = await clickAndConfirm();
-    if(!ok){ log("retrying..."); await sleep(500); ok = await clickAndConfirm(); }
-    if(!ok){ log("state_not_changed"); return send("LIKE_SKIP","state_not_changed"); }
+    if (!ok) {
+      log('retrying...');
+      await sleep(500);
+      ok = await clickAndConfirm();
+    }
+    if (!ok) {
+      log('state_not_changed');
+      return send('LIKE_SKIP', 'state_not_changed');
+    }
 
-    if(mode==="modal") ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click();
-    log("LIKE_DONE"); return send("LIKE_DONE");
-  }catch(e){
-    console.error("[LIKER] exception", e);
-    return send("LIKE_SKIP","exception");
+    if (mode === 'modal') ctx.querySelector('[aria-label*="Fechar" i],[aria-label*="Close" i]')?.click();
+    log('LIKE_DONE');
+    return send('LIKE_DONE');
+  } catch (e) {
+    console.error('[LIKER] exception', e);
+    return send('LIKE_SKIP', 'exception');
   }
 })();
 


### PR DESCRIPTION
## Summary
- close temporary like tab and return mode, reason and duration
- make first media opener and liker more resilient to interstitials and slow grids

## Testing
- `node --check background.js`
- `node --check liker.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9dcc2ca8c8326a55e9b53ca5b0f75